### PR TITLE
Fix OUnit suite to exit non-zero on failure

### DIFF
--- a/lib_test/test_pci.ml
+++ b/lib_test/test_pci.ml
@@ -17,14 +17,14 @@ let smoke_test () =
 let test_with_access_cleanup () =
   (* Get overhead for calling the fuction and the measuremnt functions *)
   let _ = Gc.compact (); resident_pages () in
-  for i = 1 to 1000 do with_dump ~cleanup:true (fun _ -> ()) done;
+  for i = 1 to 4000 do with_dump ~cleanup:true (fun _ -> ()) done;
   let mem = Gc.compact (); resident_pages () in
   (* The incremental cost of calling with_access should be 0 *)
-  for i = 1 to 1000 do with_dump ~cleanup:true (fun _ -> ()) done;
+  for i = 1 to 100 do with_dump ~cleanup:true (fun _ -> ()) done;
   let mem' = Gc.compact (); resident_pages () in
   assert_equal ~printer:(Printf.sprintf "VmRSS = %d pages") mem mem';
   (* Checking for a difference with cleanup=false as a negative test *)
-  for i = 1 to 1000 do with_dump ~cleanup:false (fun _ -> ()) done;
+  for i = 1 to 100 do with_dump ~cleanup:false (fun _ -> ()) done;
   let mem'' = Gc.compact (); resident_pages () in
   assert_raises (OUnitTest.OUnit_failure "not equal") (fun () ->
     assert_equal mem' mem'')
@@ -36,4 +36,4 @@ let _ =
       "test_with_access_cleanup" >:: test_with_access_cleanup;
     ]
   in
-  run_test_tt suite
+  OUnit2.run_test_tt_main @@ ounit2_of_ounit1 suite


### PR DESCRIPTION
Seems I've had to tweak the leak test to accomodate for the differences between
OUnit and OUnit2.

Signed-off-by: Si Beaumont simon.beaumont@citrix.com
