### PR TITLE
Use unreleased version of bisect_ppx

### DIFF
--- a/.coverage.sh
+++ b/.coverage.sh
@@ -12,6 +12,7 @@ if [ -z "$KEEP" ]; then trap "popd; rm -rf $COVERAGE_DIR" EXIT; fi
 $(which cp) -r ../* .
 
 eval `opam config env`
+opam pin add -n bisect_ppx git://github.com/rleonid/bisect_ppx#0.2.2
 opam install -y bisect_ppx oasis ocveralls
 
 sed -i '/BuildDepends:/ s/$/, bisect_ppx/' _oasis


### PR DESCRIPTION
This can be removed when https://github.com/ocaml/opam-repository/pull/4226 is merged.

Signed-off-by: Si Beaumont simon.beaumont@citrix.com
