### PR TITLE
pci: use CArray instead of Buffer

### DIFF
--- a/bindings/ffi_bindings.ml
+++ b/bindings/ffi_bindings.ml
@@ -264,15 +264,15 @@ module Bindings (F : Cstubs.FOREIGN) = struct
 
   let pci_lookup_name_1_ary =
     foreign "pci_lookup_name"
-      (Pci_access.t @-> string @-> int @-> int @-> int @-> returning string)
+      (Pci_access.t @-> ptr char @-> int @-> int @-> int @-> returning string)
 
   let pci_lookup_name_2_ary =
     foreign "pci_lookup_name"
-      (Pci_access.t @-> string @-> int @-> int @-> int @-> int @-> returning string)
+      (Pci_access.t @-> ptr char @-> int @-> int @-> int @-> int @-> returning string)
 
   let pci_lookup_name_4_ary =
     foreign "pci_lookup_name"
-      (Pci_access.t @-> string @-> int @-> int @-> int @-> int @-> int @-> int @-> returning string)
+      (Pci_access.t @-> ptr char @-> int @-> int @-> int @-> int @-> int @-> int @-> returning string)
 
   let pci_load_name_list =
     foreign "pci_load_name_list" (Pci_access.t @-> returning int)

--- a/lib/pci.ml
+++ b/lib/pci.ml
@@ -73,8 +73,17 @@ let maybe f = function
 let scan_bus = B.pci_scan_bus
 
 let with_string ?(size=1024) f =
-  let buf = Bytes.make size '\000' in
-  f buf size
+  (* Using an ocaml string violates this rule from the ctypes FAQ:
+   * string is unsuitable for binding to C functions that write
+   * into the string.
+   * The caveats from ocaml_string do not apply (we do not release
+   * the runtime lock (the default) or call back into OCaml from
+   * these functions), because string actually does a copy,
+   * however the lifetime of the value returned by libpci is bound
+   * to the lifetime of the input parameter, which can be moved
+   * by the GC and cause problems. *)
+  let buf = CArray.make char ~initial:'\x00' size in
+  f (CArray.start buf) size
 
 let lookup_class_name pci_access class_id =
   with_string (fun buf size ->


### PR DESCRIPTION
The original code was passing an ocaml managed Buffer as
a buffer for `pciutils` to write the pci names. This can
have unexpected consequences, and in our case was causing
some random segfaults (see https://github.com/xapi-project/xen-api/pull/3429).

As recommended also in [ctypes FAQ](https://github.com/ocamllabs/ocaml-ctypes/wiki/FAQ#-whats-the-best-way-to-bind-c-functions-that-act-on-strings)
we can solve this issue by allocating a C array (that lives
outside the ocaml heap) and use it as the string buffer
expected by the C function. This is still managed by ocaml
and will be freed by the GC once it is no longer in use
but it will not change unexpectedly under our feet.

Signed-off-by: Marcello Seri <marcello.seri@gmail.com>