### PR TITLE
Keep string alive over C function call

### DIFF
--- a/lib/pci.ml
+++ b/lib/pci.ml
@@ -83,7 +83,11 @@ let with_string ?(size=1024) f =
    * to the lifetime of the input parameter, which can be moved
    * by the GC and cause problems. *)
   let buf = CArray.make char ~initial:'\x00' size in
-  f (CArray.start buf) size
+  let s = CArray.start buf in
+  let r = f s size in
+  (* Keep `s` alive through the C binding invocation in `f` *)
+  ignore (Obj.repr s |> Obj.tag);
+  r
 
 let lookup_class_name pci_access class_id =
   with_string (fun buf size ->

--- a/lib/pci.ml
+++ b/lib/pci.ml
@@ -86,7 +86,7 @@ let with_string ?(size=1024) f =
   let s = CArray.start buf in
   let r = f s size in
   (* Keep `s` alive through the C binding invocation in `f` *)
-  ignore (Obj.repr s |> Obj.tag);
+  ignore (List.hd [s] |> Obj.repr |> Obj.tag);
   r
 
 let lookup_class_name pci_access class_id =


### PR DESCRIPTION
To avoid the GC removing a string where C code writes a result, use it
after the call. See also

https://github.com/xapi-project/xen-api/commit/bc053bbe0b930c58f0da403a5e8ac6bcdeb7a026

In the commit above, Sys.opaque_identity was used to keep the value
alive. However, it is not available in the OCaml 4.02.3 compiler.

Signed-off-by: Christian Lindig <christian.lindig@citrix.com>